### PR TITLE
Several minor changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "fusee-launcher"]
 	path = fusee-launcher
-	url = https://github.com/reswitched/fusee-launcher
+	url = https://github.com/reswitched/fusee-launcher.git
+	branch = master

--- a/README.md
+++ b/README.md
@@ -74,4 +74,6 @@ It seems like rocontrol doesn't have access to your USB ports. You'll need to ru
 Uh-oh, that's not good. [Open up an issue](https://github.com/moriczgergo/rocontrol/issues/new) with the exact error message, and some more info. (e.g.: your payload, the machine you're running the script on)
 
 #### It says it can't connect to the display.
-Run `xhost +localhost`, and `xhost +`.
+Either:
+ - Use gksu/gksudo: `gksu ./app.py`.
+ - Run `xhost +localhost`, and `xhost +`.

--- a/app.py
+++ b/app.py
@@ -35,10 +35,7 @@ def fusee_exec(payload):
 
     result = 0 # default result
 
-    # cwd trickery, for fusée's well being with intermezzo (TODO: Test if this is needed for sure)
-    os.chdir(fuseeLauncherDir)
-
-    p = subprocess.Popen([sys.executable, fuseeFilePath, payload], stdout=subprocess.PIPE, stderr=subprocess.PIPE) # run fusée gelée
+    p = subprocess.Popen([sys.executable, fuseeFilePath, payload, '--relocator', os.path.join(fuseeLauncherDir, 'intermezzo.bin')], stdout=subprocess.PIPE, stderr=subprocess.PIPE) # run fusée gelée
     p.wait() # wait for it to close
 
     output = p.stdout.read().decode("utf-8")

--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from tkinter import *
 from tkinter import messagebox, filedialog
 import os, sys


### PR DESCRIPTION
 - Instead of changing directory to fusee-launcher to use intermezzo.bin, just specify it with fusee-launcher.py's --relocator argument
 - Add shebang at the beginning of the file to let users run it as a binary, e.g. `./app.py`
 - In the readme, mention using gksu and gksudo, which are commonly used to run graphical programs with require root privileges
 - Track the master branch tip instead of a specific commit (so when fusee-launcher is committed to the submodule will automatically point to that commit)

Feel free to dismiss any of these if you don't like them.